### PR TITLE
scalafmt: only format src/

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,7 @@
 version = 3.7.9
 
 runner.dialect = scala212
+
+project.includePaths = [
+  "glob:**/src/**/*.scala"
+]


### PR DESCRIPTION
After adding metals, `scalafmt` trips up on trying to format the scala files under `.metals`.

Adjusting the configuration to only format `src` avoids this.