### PR TITLE
Update scala3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version = 3.7.9
 
-runner.dialect = scala212
+runner.dialect = scala3
 
 project.includePaths = [
   "glob:**/src/**/*.scala"

--- a/build.gradle
+++ b/build.gradle
@@ -34,13 +34,13 @@ def hasGCC = hasExeOnPath('gcc')
 def hasClang = hasExeOnPath('clang')
 
 dependencies {
-    implementation 'org.scala-lang:scala-library:2.13.14'
-    implementation 'io.argonaut:argonaut_2.13:6.2.6'
+    implementation 'org.scala-lang:scala3-library_3:3.4.2'
+    implementation 'io.argonaut:argonaut_3:6.2.6'
 
     implementation 'org.antlr:antlr4-runtime:4.5'
     implementation 'org.antlr:ST4:4.0.8'
 
-    testImplementation 'org.scalatest:scalatest_2.13:3.2.17'
+    testImplementation 'org.scalatest:scalatest_3:3.2.17'
     testImplementation 'com.vladsch.flexmark:flexmark-all:0.64.8'
 
     antlr 'org.antlr:antlr4:4.5'

--- a/c-worksheet-instrumentor.nix
+++ b/c-worksheet-instrumentor.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     installPhase = ''
       runHook preInstall
 
-      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\|module\)' \
         | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
         | sh
 
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Remember to update FOD outputHash whenever build.gradle dependencies change
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "sha256-DxthMN/wRt1kpqD89qkCQ5WlYJiNnyQssSdRvxEfRkM=";
+    outputHash = "sha256-xw7DoUKkGYsGxVHxgl3qhWjQRanHvGDyP2jVt3ynjGw=";
   };
 
   nativeBuildInputs = [

--- a/src/main/scala/edu/nus/worksheet/WorksheetOutput.scala
+++ b/src/main/scala/edu/nus/worksheet/WorksheetOutput.scala
@@ -25,12 +25,16 @@ class WorksheetOutput(
   }
 
   // General output from program. e.g. printf
-  def addLineOfOutput(lineNum: Int, line: String, force: Boolean = false): Unit = {
+  def addLineOfOutput(
+      lineNum: Int,
+      line: String,
+      force: Boolean = false
+  ): Unit = {
     val ml = outputPerLine.getOrElseUpdate(lineNum, ListBuffer())
 
-    val message = if (ml.length < maxOutputPerLine || force) {
+    val message = if ml.length < maxOutputPerLine || force then {
       Some(line);
-    } else if (ml.length == maxOutputPerLine) {
+    } else if ml.length == maxOutputPerLine then {
       Some("... [output truncated]");
     } else {
       None
@@ -60,16 +64,18 @@ class WorksheetOutput(
     addLineOfOutput(lineNum, line);
 
   // Assumes that it stars from wsCol anyway, so doesn't prepend with any padding.
-  def generateWorksheetOutputForLine(outputForLineIter: Iterator[String]): String = {
+  def generateWorksheetOutputForLine(
+      outputForLineIter: Iterator[String]
+  ): String = {
     val res = new StringBuilder();
 
-    if (outputForLineIter.hasNext) {
+    if outputForLineIter.hasNext then {
       // The first line of the output.
       res.append(prefixes(0)); // the " //> "
       res.append(outputForLineIter.next());
 
       // Subsequent lines of output.
-      while (outputForLineIter.hasNext) {
+      while outputForLineIter.hasNext do {
         res.append('\n' + (" " * colForWS));
         res.append(prefixes(1)); // the " //| "
         res.append(outputForLineIter.next());
@@ -97,9 +103,9 @@ class WorksheetOutput(
     // Take each line of input, and `combine" it will the List of its output
     val res = new StringBuilder;
 
-    for ((line, lineNum) <- src.zipWithIndex) {
+    for (line, lineNum) <- src.zipWithIndex do {
       // Ensures output always starts on a new line.
-      if (res.lastIndexOf("\n") != res.length - 1) {
+      if res.lastIndexOf("\n") != res.length - 1 then {
         res.append('\n');
       }
 
@@ -114,7 +120,7 @@ class WorksheetOutput(
           // Guarantee that handleOutput always starts at colForWS column
           val lastLineLength = res.length - res.lastIndexOf("\n");
           val outputPadding =
-            if (lastLineLength <= colForWS + 1) {
+            if lastLineLength <= colForWS + 1 then {
               " " * (colForWS - lastLineLength + 1);
             } else {
               // If the src line is too long,
@@ -125,7 +131,7 @@ class WorksheetOutput(
 
           // val outputForLine = output.getOrElse(lineNum, List())
           val wsOutput = generateWorksheetOutputForLine(outputForLine.iterator);
-          if (!wsOutput.isEmpty()) {
+          if !wsOutput.isEmpty() then {
             res.append(outputPadding);
             res.append(wsOutput);
           }

--- a/src/main/scala/edu/nus/worksheet/Worksheetify.scala
+++ b/src/main/scala/edu/nus/worksheet/Worksheetify.scala
@@ -1,15 +1,15 @@
 package edu.nus.worksheet
 
-import scala.io._
-import java.io._
+import scala.io.*
+import java.io.*
 import scala.sys.process.{Process, ProcessIO}
 import scala.collection.mutable
 import scala.concurrent.{Channel, Promise}
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Random;
 import java.util.regex.Pattern
-import edu.nus.worksheet.instrumentor._
+import edu.nus.worksheet.instrumentor.*
 
 object Worksheetify {
   val MaxIterationsDefault = 10000;
@@ -71,32 +71,30 @@ object Worksheetify {
           def isAncestorOfCurrentBlock(bn: String): Boolean =
             currentBlock().startsWith(bn);
 
-          if (isAncestorOfCurrentBlock(blockName))
+          if isAncestorOfCurrentBlock(blockName) then
             pred(currentIterationInBlock(blockName));
-          else
-            true;
+          else true;
         })
 
         // Predicate whether to 'output' for the current block/line
         val currentBlockPredicate =
-          blockFilters.getOrElse(currentBlock(), { _: Int => true; });
+          blockFilters.getOrElse(currentBlock(), { (_: Int) => true; });
         val currentBlockIteration = currentIterationInBlock(currentBlock());
 
         // println(currentLine() + ":WS " + s);
-        if (filtersSatisfied)
-          if (currentBlockIteration > 0)
+        if filtersSatisfied then
+          if currentBlockIteration > 0 then
             outputTo.addWorksheetOutput(
               currentLine(),
               s + s"\t[iteration:$currentBlockIteration]"
             );
-          else
-            outputTo.addWorksheetOutput(currentLine(), s);
+          else outputTo.addWorksheetOutput(currentLine(), s);
       }
 
-      for (line <- lines) {
+      for line <- lines do {
         line match {
           case LineNum(s, d, blockName, blockIteration) => {
-            if (s.length() > 0) {
+            if s.length() > 0 then {
               hasStdout.add(currentLine())
               output(s);
             }
@@ -108,7 +106,7 @@ object Worksheetify {
             output(s);
           }
           case WorksheetResult(pre, s) => {
-            if (pre.length() > 0) {
+            if pre.length() > 0 then {
               hasStdout.add(currentLine())
               output(pre);
             }
@@ -118,7 +116,7 @@ object Worksheetify {
             //  (and screws up with the tests). So, only output a result if there's no output to
             //  STDOUT on the same line already.
             val hasNoOutputOnLine = !hasStdout.contains(currentLine());
-            if (hasNoOutputOnLine) {
+            if hasNoOutputOnLine then {
               output(s);
             }
           }
@@ -155,7 +153,7 @@ object Worksheetify {
     val originalProgram = new CProgram(inputProgramSrc, cc = cc);
     val (inputWarnings, inputErrors) = originalProgram.checkForErrors();
 
-    if (!inputErrors.isEmpty) {
+    if !inputErrors.isEmpty then {
       // println("There were errors! Stopping.");
 
       def messageFor(d: Diagnostic): String =
@@ -187,7 +185,7 @@ object Worksheetify {
     // It should: Given a C program which compiles,
     //  our instrumenting shouldn't introduce any errors.
     // - If it does not, this is a bug; but should fail with dignity.
-    if (!instrumentedErrors.isEmpty) {
+    if !instrumentedErrors.isEmpty then {
       val errorMessages = instrumentedErrors.map(_.diagnosticMessage());
       throw new UnableToInstrumentException(
         srcLines.mkString("\n"),
@@ -245,7 +243,7 @@ object Worksheetify {
   }
 
   def main(args: Array[String]): Unit = {
-    if (args.length == 0) {
+    if args.length == 0 then {
       println("Expected: java Worksheetify <input>.c");
       return;
     }
@@ -268,10 +266,8 @@ object Worksheetify {
         val lineToAddMessageAt = 0;
         val inputWithMessage = inputLines.zipWithIndex
           .map({ case (l, i) =>
-            if (i == lineToAddMessageAt)
-              l + s" // Failed to instrument";
-            else
-              l;
+            if i == lineToAddMessageAt then l + s" // Failed to instrument";
+            else l;
           })
           .mkString("\n");
 

--- a/src/main/scala/edu/nus/worksheet/WorksheetifyScratch.scala
+++ b/src/main/scala/edu/nus/worksheet/WorksheetifyScratch.scala
@@ -1,6 +1,6 @@
 package edu.nus.worksheet
 
-import edu.nus.worksheet.instrumentor._;
+import edu.nus.worksheet.instrumentor.*;
 
 object WorksheetifyScratch {
 

--- a/src/main/scala/edu/nus/worksheet/WorksheetifyServer.scala
+++ b/src/main/scala/edu/nus/worksheet/WorksheetifyServer.scala
@@ -222,7 +222,7 @@ object WorksheetifyServer {
               System.exit(0);
             }
           },
-          5 * 60 * 1000
+          1 * 60 * 1000
         );
       }
 

--- a/src/main/scala/edu/nus/worksheet/instrumentor/CDecl.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/CDecl.scala
@@ -2,8 +2,8 @@
 // perhaps move to its own project in Java.
 package edu.nus.worksheet.instrumentor;
 
-import org.antlr.v4.runtime._
-import org.antlr.v4.runtime.tree._
+import org.antlr.v4.runtime.*
+import org.antlr.v4.runtime.tree.*
 import edu.nus.worksheet.instrumentor.Util.getANTLRLexerTokensParserFor;
 
 // Pass through a "gibberish" (C) declaration, come up with English terms.
@@ -16,12 +16,11 @@ class GibberishPhase(val tokens: BufferedTokenStream)
   override def visitDeclaration(ctx: CParser.DeclarationContext): String = {
     val declSpecs = visit(ctx.declarationSpecifiers());
     val theRest =
-      if (ctx.maybeInitDeclaratorList().initDeclaratorList() != null)
+      if ctx.maybeInitDeclaratorList().initDeclaratorList() != null then
         visit(
           ctx.maybeInitDeclaratorList().initDeclaratorList()
         ); // assume only one variable for now.
-      else
-        "";
+      else "";
 
     return theRest + declSpecs;
   }
@@ -40,11 +39,10 @@ class GibberishPhase(val tokens: BufferedTokenStream)
 
   override def visitPointer(ctx: CParser.PointerContext): String = {
     val typeQuals =
-      if (ctx.typeQualifierList() != null)
+      if ctx.typeQualifierList() != null then
         rewriter.getText(ctx.typeQualifierList().getSourceInterval()) + " "
-      else
-        "";
-    return typeQuals + "pointer to " + (if (ctx.pointer() != null)
+      else "";
+    return typeQuals + "pointer to " + (if ctx.pointer() != null then
                                           visit(ctx.pointer())
                                         else "");
   }
@@ -60,7 +58,7 @@ class GibberishPhase(val tokens: BufferedTokenStream)
 
   override def visitDeclarator(ctx: CParser.DeclaratorContext): String = {
     val directDecl = visit(ctx.directDeclarator());
-    return directDecl + (if (ctx.pointer() != null) visit(ctx.pointer())
+    return directDecl + (if ctx.pointer() != null then visit(ctx.pointer())
                          else "");
   }
 
@@ -79,12 +77,11 @@ class GibberishPhase(val tokens: BufferedTokenStream)
     // or just not there, e.g. in "int arr[] = { 1, 2 };"
     val directDecl = visit(ctx.directDeclarator());
     val arrSizeExpr =
-      if (ctx.assignmentExpression() != null)
+      if ctx.assignmentExpression() != null then
         rewriter.getText(
           ctx.assignmentExpression().getSourceInterval()
         ) + " "; // visit?
-      else
-        "";
+      else "";
     return directDecl + "array " + arrSizeExpr + "of ";
   }
 
@@ -94,19 +91,16 @@ class GibberishPhase(val tokens: BufferedTokenStream)
     val directDecl = visit(ctx.directDeclarator());
 
     val params =
-      if (ctx.parameterTypeList() != null)
-        visit(ctx.parameterTypeList())
-      else
-        "";
+      if ctx.parameterTypeList() != null then visit(ctx.parameterTypeList())
+      else "";
 
     return directDecl + "function (" + params + ") returning "
   }
 
   override def visitParameterList(ctx: CParser.ParameterListContext): String = {
-    return (if (ctx.parameterList() != null)
+    return (if ctx.parameterList() != null then
               visit(ctx.parameterList()) + ", "
-            else
-              "") +
+            else "") +
       visit(ctx.parameterDeclaration());
   }
 
@@ -114,16 +108,12 @@ class GibberishPhase(val tokens: BufferedTokenStream)
       ctx: CParser.ParameterDeclarationContext
   ): String = {
     val abstrDecl =
-      if (ctx.abstractDeclarator() != null)
-        visit(ctx.abstractDeclarator())
-      else
-        "";
+      if ctx.abstractDeclarator() != null then visit(ctx.abstractDeclarator())
+      else "";
     // need to figure out which rule it is.
     val declSpecs = visit(
-      if (ctx.declarationSpecifiers() != null)
-        ctx.declarationSpecifiers()
-      else
-        ctx.declarationSpecifiers2()
+      if ctx.declarationSpecifiers() != null then ctx.declarationSpecifiers()
+      else ctx.declarationSpecifiers2()
     );
     return abstrDecl + declSpecs;
   }

--- a/src/main/scala/edu/nus/worksheet/instrumentor/CProgram.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/CProgram.scala
@@ -1,7 +1,7 @@
 package edu.nus.worksheet.instrumentor
 
-import scala.io._
-import scala.sys.process._
+import scala.io.*
+import scala.sys.process.*
 import java.io.File
 import java.util.regex.Pattern
 import scala.concurrent.{Channel, Promise}
@@ -94,7 +94,7 @@ class CProgram(
     val processIO = new ProcessIO(handleIn, handleOut, { _ => () });
     val compileResult = Process(compileCommand).run(processIO).exitValue();
 
-    return if (compileResult != 0) {
+    return if compileResult != 0 then {
       None;
     } else {
       Some(outputChannel.read);
@@ -128,7 +128,7 @@ class CProgram(
       val warnings = new ListBuffer[WarningMessage]();
       val errors = new ListBuffer[ErrorMessage]();
 
-      for (err <- Source.fromInputStream(input).getLines()) {
+      for err <- Source.fromInputStream(input).getLines() do {
         err match {
           case Diagnostic.Warning(src, line, col, msg) => {
             warnings += WarningMessage(src, line.toInt, col.toInt, msg);

--- a/src/main/scala/edu/nus/worksheet/instrumentor/CType.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/CType.scala
@@ -3,7 +3,7 @@ package edu.nus.worksheet.instrumentor
 import java.util.regex.Pattern;
 import scala.beans.BeanProperty;
 import scala.collection.mutable;
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import Util.someOrNone;
 
 // Making use of CType allows us to pass objects to
@@ -72,7 +72,7 @@ case class ArrayType(
       // a[i] => (*a + i)
       ofId match {
         case OfIdRegex(_, offset) => {
-          if (offset != "" && offset != "0") {
+          if offset != "" && offset != "0" then {
             s"(*${getId()} + ($offset))";
           } else {
             s"(*${getId()})";
@@ -93,7 +93,7 @@ case class ArrayType(
     //   Arr(x, Prim(x[x_0]))
     // So, we need to keep the last [..] in the `of` CType
     def fOf(ofId: String): String = {
-      if (ofId != null && ofId.length > 0) {
+      if ofId != null && ofId.length > 0 then {
         val idx = ofId.lastIndexOf('[');
         val (arrId, subscript) = (ofId.substring(0, idx), ofId.substring(idx));
         f(arrId) + subscript;
@@ -171,7 +171,7 @@ case class StructType(
     val membersMap = new mutable.LinkedHashMap[String, CType]();
 
     val structIdLen = getId().length();
-    for (m <- members) {
+    for m <- members do {
       val memberName = m
         .fId({ mId => mId.substring(mId.lastIndexOf('.')) })
         .id

--- a/src/main/scala/edu/nus/worksheet/instrumentor/CTypeCodec.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/CTypeCodec.scala
@@ -1,6 +1,6 @@
 package edu.nus.worksheet.instrumentor
 
-import argonaut._, Argonaut._
+import argonaut.*, Argonaut.*
 
 object CTypeCodec {
   implicit def CTypeEncodeJson: EncodeJson[CType] =

--- a/src/main/scala/edu/nus/worksheet/instrumentor/CTypeFromDeclaration.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/CTypeFromDeclaration.scala
@@ -1,11 +1,11 @@
 package edu.nus.worksheet.instrumentor
 
-import org.antlr.v4.runtime._
-import org.antlr.v4.runtime.tree._
+import org.antlr.v4.runtime.*
+import org.antlr.v4.runtime.tree.*
 import scala.collection.immutable.List
 import scala.collection.mutable.Stack;
 import scala.collection.mutable.Map;
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import edu.nus.worksheet.instrumentor.Util.currentScopeForContext;
 
 class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
@@ -13,14 +13,14 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
   def listOfInitDeclrList(
       ctx: CParser.InitDeclaratorListContext
   ): Seq[CParser.InitDeclaratorContext] =
-    if (ctx.initDeclaratorList() != null) {
+    if ctx.initDeclaratorList() != null then {
       listOfInitDeclrList(ctx.initDeclaratorList()) :+ ctx.initDeclarator();
     } else {
       Seq(ctx.initDeclarator());
     }
 
   def listOfPointer(ctx: CParser.PointerContext): Seq[String] =
-    if (ctx.pointer() != null) {
+    if ctx.pointer() != null then {
       listOfPointer(ctx.pointer()) :+ ctx.getChild(0).getText();
     } else {
       Seq(ctx.getText());
@@ -30,7 +30,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
       declaredType: CType,
       pointer: CParser.PointerContext
   ): CType = {
-    val pointers = if (pointer != null) listOfPointer(pointer) else Seq();
+    val pointers = if pointer != null then listOfPointer(pointer) else Seq();
 
     return pointers.foldLeft(declaredType)({ (ct, ptr) =>
       ct match {
@@ -51,33 +51,32 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
       case declarationCtx: CParser.DeclarationContext =>
         declarationCtx.isTypedef;
       case _ => {
-        if (ctx.getParent() != null)
+        if ctx.getParent() != null then
           isInDeclarationContextWithTypedef(ctx.getParent());
-        else
-          false;
+        else false;
       }
     }
 
   def ctypeOfEnumSpecifier(ctx: CParser.EnumSpecifierContext): EnumType =
-    if (ctx.enumeratorList() != null) {
+    if ctx.enumeratorList() != null then {
       var constants = Seq[String]();
 
       var list = ctx.enumeratorList();
-      while (list != null) {
+      while list != null do {
         constants =
           list.enumerator().enumerationConstant().getText() +: constants;
         list = list.enumeratorList();
       }
 
       val enumTag =
-        if (ctx.Identifier() != null) Some(ctx.Identifier().getText())
+        if ctx.Identifier() != null then Some(ctx.Identifier().getText())
         else None;
 
       EnumType(None, enumTag, constants);
     } else {
       val enumTag = ctx.Identifier().getText();
       currentScopeForContext(ctx, scopes).resolveEnum(enumTag) match {
-        case Some(enum) => enum;
+        case Some(enum_) => enum_;
         case None => throw new RuntimeException(s"struct $enumTag undeclared!");
       }
     }
@@ -86,7 +85,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
     val specrs = listOfStructDeclarationSpecifiers(ctx.specifierQualifierList())
     val specifiedType = ctypeFromSpecifiers(specrs);
 
-    if (ctx.abstractDeclarator() != null) {
+    if ctx.abstractDeclarator() != null then {
       ctypeOf(specifiedType, ctx.abstractDeclarator());
     } else {
       specifiedType;
@@ -97,7 +96,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
       specsCtx: CParser.SpecifierQualifierListContext
   ): Seq[RuleContext] = {
     def asList(ctx: CParser.SpecifierQualifierListContext): Seq[RuleContext] =
-      if (ctx.specifierQualifierList() != null) {
+      if ctx.specifierQualifierList() != null then {
         ctx.getChild(0).asInstanceOf[RuleContext] +: asList(
           ctx.specifierQualifierList()
         );
@@ -120,7 +119,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
   def declaratorsOfStructDeclaratorList(
       ctx: CParser.StructDeclaratorListContext
   ): Seq[CParser.DeclaratorContext] =
-    if (ctx.structDeclaratorList() != null) {
+    if ctx.structDeclaratorList() != null then {
       declaratorsOfStructDeclaratorList(ctx.structDeclaratorList()) :+ ctx
         .structDeclarator()
         .declarator();
@@ -137,7 +136,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
   }
 
   def ctypesOf(ctx: CParser.StructDeclarationListContext): Seq[CType] =
-    if (ctx.structDeclarationList() != null) {
+    if ctx.structDeclarationList() != null then {
       ctypesOf(ctx.structDeclarationList()) ++ ctypesOf(
         ctx.structDeclaration()
       );
@@ -146,7 +145,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
     }
 
   def ctypeOf(ctx: CParser.ParameterDeclarationContext): CType =
-    if (ctx.declarator() != null) {
+    if ctx.declarator() != null then {
       val specifiedType = ctypeOf(ctx.declarationSpecifiers());
       ctypeOfDeclarator(specifiedType, ctx.declarator());
     } else {
@@ -157,7 +156,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
         )
       );
 
-      if (ctx.abstractDeclarator() != null) {
+      if ctx.abstractDeclarator() != null then {
         ctypeOf(specifiedType, ctx.abstractDeclarator());
       } else {
         specifiedType;
@@ -165,14 +164,14 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
     }
 
   def ctypesOf(ctx: CParser.ParameterListContext): Seq[CType] =
-    if (ctx.parameterList() != null) {
+    if ctx.parameterList() != null then {
       ctypesOf(ctx.parameterList()) :+ ctypeOf(ctx.parameterDeclaration());
     } else {
       Seq(ctypeOf(ctx.parameterDeclaration()));
     }
 
   def ctypesOf(ctx: CParser.ParameterTypeListContext): Seq[CType] =
-    if (ctx.getChild(1) != null) {
+    if ctx.getChild(1) != null then {
       ctypesOf(ctx.parameterList()) :+ VarArgType();
     } else {
       ctypesOf(ctx.parameterList())
@@ -181,15 +180,13 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
   def ctypeOfStructOrUnionSpecifier(
       ctx: CParser.StructOrUnionSpecifierContext
   ): CType =
-    if (ctx.structDeclarationList() != null) {
+    if ctx.structDeclarationList() != null then {
       // in the form of "struct Identifier? { structDeclList };",
       // (null for anonymous struct).
       val structOrUnion = ctx.structOrUnion().getText();
       val structTag =
-        if (ctx.Identifier() != null)
-          Some(ctx.Identifier().getText())
-        else
-          None;
+        if ctx.Identifier() != null then Some(ctx.Identifier().getText())
+        else None;
 
       val members = ctypesOf(ctx.structDeclarationList());
 
@@ -212,7 +209,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
   ): Seq[RuleContext] =
     specsCtx
       .map({ specifier =>
-        if (specifier.typeSpecifier() != null) {
+        if specifier.typeSpecifier() != null then {
           Some(specifier.typeSpecifier()); // Take the typeSpecifiers
         } else {
           None; // Ignore everything else.
@@ -289,7 +286,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
         val id = ctx.getText();
 
         // Might be a typedef, which we need to track.
-        if (isInDeclarationContextWithTypedef(ctx)) {
+        if isInDeclarationContextWithTypedef(ctx) then {
           currentScopeForContext(ctx, scopes).defineTypedef(id, specifiedType);
         }
 
@@ -298,7 +295,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
       case ctx: CParser.DeclaredParenthesesContext =>
         ctypeOfDeclarator(specifiedType, ctx.declarator());
       case ctx: CParser.DeclaredArrayContext => {
-        val n = if (ctx.assignmentExpression() != null) {
+        val n = if ctx.assignmentExpression() != null then {
           val typeInfer = new TypeInference(scopes, this);
           typeInfer.visit(ctx.assignmentExpression()).id;
         } else {
@@ -334,7 +331,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
       case ctx: CParser.AbstractDeclaredParenthesesContext =>
         ctypeOf(specifiedType, ctx.abstractDeclarator());
       case ctx: CParser.AbstractDeclaredArrayContext => {
-        val n = if (ctx.assignmentExpression() != null) {
+        val n = if ctx.assignmentExpression() != null then {
           val typeInfer = new TypeInference(scopes, this);
           typeInfer.visit(ctx.assignmentExpression()).id;
         } else {
@@ -344,7 +341,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
         }
 
         val arrType = ArrayType(None, None, n, specifiedType);
-        if (ctx.directAbstractDeclarator() != null) {
+        if ctx.directAbstractDeclarator() != null then {
           ctypeOfAbstractDirectDeclarator(
             arrType,
             ctx.directAbstractDeclarator()
@@ -355,13 +352,12 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
       }
       case ctx: CParser.AbstractDeclaredFunctionPrototypeContext => {
         val paramTypes =
-          if (ctx.parameterTypeList() != null)
+          if ctx.parameterTypeList() != null then
             ctypesOf(ctx.parameterTypeList())
-          else
-            Seq();
+          else Seq();
         val fnType = FunctionType(None, specifiedType, paramTypes);
 
-        if (ctx.directAbstractDeclarator() != null) {
+        if ctx.directAbstractDeclarator() != null then {
           ctypeOfAbstractDirectDeclarator(
             fnType,
             ctx.directAbstractDeclarator()
@@ -376,7 +372,7 @@ class CTypeFromDeclaration(scopes: ParseTreeProperty[Scope]) {
       specifiedType: CType,
       ctx: CParser.AbstractDeclaratorContext
   ): CType = {
-    if (ctx.directAbstractDeclarator() != null) {
+    if ctx.directAbstractDeclarator() != null then {
       val ptype = pointerTypeOfDeclaredType(specifiedType, ctx.pointer());
       ctypeOfAbstractDirectDeclarator(ptype, ctx.directAbstractDeclarator());
     } else {

--- a/src/main/scala/edu/nus/worksheet/instrumentor/CTypeToDeclaration.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/CTypeToDeclaration.scala
@@ -34,7 +34,7 @@ object CTypeToDeclaration {
           }
         }
       case EnumType(_, tag, _) => {
-        if (tag != null) {
+        if tag != null then {
           (s"enum $tag", "");
         } else {
           throw new UnsupportedOperationException(
@@ -44,7 +44,7 @@ object CTypeToDeclaration {
       }
       case FunctionType(_, rtnType, params) => {
         val (rtnS, rtnD) = specsDeclrOf(rtnType, "");
-        val rtnDStr = if (rtnD != "") rtnD + " " else "";
+        val rtnDStr = if rtnD != "" then rtnD + " " else "";
         val paramS = params.map(stringOfTypeName(_)).mkString(",");
         (rtnS, s"$rtnDStr($declr)($paramS)");
       }
@@ -56,16 +56,16 @@ object CTypeToDeclaration {
 
   def declarationOf(ct: CType, id: String): String = {
     val (s, d) = specsDeclrOf(ct, id);
-    s + (if (!d.isEmpty()) " " + d; else "");
+    s + (if !d.isEmpty() then " " + d; else "");
   }
 
   def stringOfTypeName(ct: CType): String = {
     val (s, d) = specsDeclrOf(ct, "");
-    s + (if (!d.isEmpty()) " " + d; else "");
+    s + (if !d.isEmpty() then " " + d; else "");
   }
 
   def join(r: (String, String)): String = {
     val (s, d) = r;
-    s + (if (d != null) " " + d else "");
+    s + (if d != null then " " + d else "");
   }
 }

--- a/src/main/scala/edu/nus/worksheet/instrumentor/DefineScopesPhase.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/DefineScopesPhase.scala
@@ -1,14 +1,15 @@
 package edu.nus.worksheet.instrumentor
 
+import scala.compiletime.uninitialized
 import scala.collection.mutable;
-import org.antlr.v4.runtime._
-import org.antlr.v4.runtime.tree._
+import org.antlr.v4.runtime.*
+import org.antlr.v4.runtime.tree.*
 import edu.nus.worksheet.instrumentor.Util.idOfDeclarator;
 
 class DefineScopesPhase extends CBaseListener {
   val scopes = new ParseTreeProperty[Scope]();
-  var globals: GlobalScope = _;
-  var currentScope: Scope = _;
+  var globals: GlobalScope = uninitialized;
+  var currentScope: Scope = uninitialized;
 
   private[instrumentor] val allScopes = mutable.ArrayBuffer[Scope]();
 
@@ -21,7 +22,9 @@ class DefineScopesPhase extends CBaseListener {
   }
 
   // For entry-level rules.
-  private[DefineScopesPhase] def setupGlobalScope(ctx: ParserRuleContext): Unit = {
+  private[DefineScopesPhase] def setupGlobalScope(
+      ctx: ParserRuleContext
+  ): Unit = {
     globals = new GlobalScope();
 
     // Save global scope to CompilationUnit ctx,

--- a/src/main/scala/edu/nus/worksheet/instrumentor/FindCompiler.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/FindCompiler.scala
@@ -11,16 +11,15 @@ object FindCompiler {
     def maybeBin(f: String): Option[String] = {
       val folder = new File(f);
 
-      if (folder.isDirectory()) {
+      if folder.isDirectory() then {
         val bin = new File(folder, binName);
         val binExe = new File(folder, f"${binName}.exe");
 
-        if (bin.exists() && bin.canExecute())
+        if bin.exists() && bin.canExecute() then
           return Some(bin.getAbsolutePath());
-        else if (binExe.exists() && binExe.canExecute())
+        else if binExe.exists() && binExe.canExecute() then
           return Some(binExe.getAbsolutePath());
-        else
-          return None;
+        else return None;
       } else {
         return None;
       }
@@ -32,11 +31,10 @@ object FindCompiler {
   def findCompilerOnPath(): String = {
     // On Windows 8.1, `os.name` is "Windows 8.1".
     val ccName =
-      if (System.getProperty("os.name").toLowerCase().contains("windows"))
+      if System.getProperty("os.name").toLowerCase().contains("windows") then
         // On Windows, we expect Mingw GCC to be on the PATH
         "gcc.exe";
-      else
-        "cc";
+      else "cc";
 
     return findOnPath(ccName) match {
       case Some(cc) => cc;

--- a/src/main/scala/edu/nus/worksheet/instrumentor/HeaderUtils.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/HeaderUtils.scala
@@ -1,10 +1,10 @@
 package edu.nus.worksheet.instrumentor
 
-import java.io._;
-import argonaut._, Argonaut._
-import CTypeCodec._;
-import StringConstruction._;
-import Util._;
+import java.io.*;
+import argonaut.*, Argonaut.*
+import CTypeCodec.*;
+import StringConstruction.*;
+import Util.*;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 object HeaderUtils {
@@ -74,7 +74,7 @@ object HeaderUtils {
 
     val cachedFile = new File(cachedHeaderFilename(header));
 
-    if (cachedFile.exists()) {
+    if cachedFile.exists() then {
       val source = scala.io.Source.fromFile(cachedFile);
       val lines =
         try source.getLines().mkString("\n")
@@ -84,7 +84,7 @@ object HeaderUtils {
       // Why, pickle, why?
       lines.decodeOption[(String, Int, HeaderCachePayload)] match {
         case Some((hdr, hdrChecksum, payload)) => {
-          if (hdrChecksum == hc) {
+          if hdrChecksum == hc then {
             Some(payload);
           } else {
             None;
@@ -162,7 +162,7 @@ object HeaderUtils {
       Iterable[EnumType],
       Iterable[(String, CType)]
   ) =
-    getWithPreprocessedHeader(header, getScopeStuffOf _) match {
+    getWithPreprocessedHeader(header, getScopeStuffOf) match {
       case Some(data) => data;
       case None       => (Seq(), Seq(), Seq(), Seq());
     }
@@ -177,13 +177,13 @@ object HeaderUtils {
   def addTypedefsOfHeaderToScope(header: String, scope: Scope): Unit = {
     val typedefs = getTypedefsOfHeader(header);
 
-    for ((typename, ct) <- typedefs) {
+    for (typename, ct) <- typedefs do {
       scope.defineTypedef(typename, ct);
     }
   }
 
   def addSymbolsOfHeaderToScope(header: String, scope: Scope) =
-    getSymbolsOfHeader(header).foreach(scope.defineSymbol _);
+    getSymbolsOfHeader(header).foreach(scope.defineSymbol);
 
   def main(args: Array[String]): Unit = {
     // String that can be sent down a wire

--- a/src/main/scala/edu/nus/worksheet/instrumentor/Instrumentor.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/Instrumentor.scala
@@ -1,12 +1,12 @@
 package edu.nus.worksheet.instrumentor
 
-import org.antlr.v4.runtime._
-import org.antlr.v4.runtime.tree._
-import org.stringtemplate.v4._
+import org.antlr.v4.runtime.*
+import org.antlr.v4.runtime.tree.*
+import org.stringtemplate.v4.*
 import scala.beans.BeanProperty
 import scala.collection.mutable
 import scala.io.Source
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.matching.Regex
 import edu.nus.worksheet.instrumentor.Util.currentScopeForContext;
 import edu.nus.worksheet.instrumentor.Util.getANTLRLexerTokensParserFor;
@@ -124,7 +124,7 @@ class Instrumentor(
 
   def getInstrumentedProgram(): String = {
     // Could sort tokens using .getTokenIndex(), if need be.
-    for (tok <- rewrites.keys) {
+    for tok <- rewrites.keys do {
       rewrites.get(tok) match {
         case Some((l, r)) => {
           rewriter.insertBefore(tok, l);
@@ -160,7 +160,9 @@ class Instrumentor(
     return preambleTemplate.render();
   }
 
-  override def enterCompilationUnit(ctx: CParser.CompilationUnitContext): Unit = {
+  override def enterCompilationUnit(
+      ctx: CParser.CompilationUnitContext
+  ): Unit = {
     rewrites.put(ctx.getStart(), (generateInstrumentorPreamble() + "\n\n", ""));
 
     // Need to add "func ptr lookup" function at the end,
@@ -233,7 +235,7 @@ class Instrumentor(
   }
 
   override def exitDeclaration(ctx: CParser.DeclarationContext): Unit = {
-    if (ctx.getParent().isInstanceOf[CParser.BlockItemContext]) {
+    if ctx.getParent().isInstanceOf[CParser.BlockItemContext] then {
       val english = new GibberishPhase(tokens).visitDeclaration(ctx);
       val wsDirective = WorksheetDirective(nonce);
 
@@ -303,7 +305,7 @@ class Instrumentor(
       try {
         val assgCType = typeInfer.visit(ctx.unaryExpression());
 
-        if (assgCType != null) {
+        if assgCType != null then {
           generateStringConstruction(assgCType, s"${assgCType.getId()} = ");
         } else {
           s"/* Couldn't find CType for $unaryStr */";
@@ -396,7 +398,7 @@ class Instrumentor(
   override def exitExpressionStatement(
       ctx: CParser.ExpressionStatementContext
   ): Unit =
-    if (ctx.expression() != null) {
+    if ctx.expression() != null then {
       ctx.expression() match {
         case fallthrough: CParser.ExprFallthroughContext =>
           addStringConstructionFor(ctx, fallthrough.assignmentExpression());
@@ -433,9 +435,11 @@ class Instrumentor(
     rewrites.put(stopTok, (la, ra + " /*OneLineWrap*/}\n"));
   }
 
-  override def exitSelectionStatement(ctx: CParser.SelectionStatementContext): Unit = {
-    for (stmt <- ctx.statement().asScala) {
-      if (stmt.compoundStatement() == null) {
+  override def exitSelectionStatement(
+      ctx: CParser.SelectionStatementContext
+  ): Unit = {
+    for stmt <- ctx.statement().asScala do {
+      if stmt.compoundStatement() == null then {
         // If the `statement` of the iterationStatement isn't a compoundStatment,
         // wrap it with { }.
         wrapStatementWithBraces(stmt);
@@ -443,16 +447,20 @@ class Instrumentor(
     }
   }
 
-  override def exitIterationStatement(ctx: CParser.IterationStatementContext): Unit = {
+  override def exitIterationStatement(
+      ctx: CParser.IterationStatementContext
+  ): Unit = {
     val stmt = ctx.statement();
-    if (stmt.compoundStatement() == null) {
+    if stmt.compoundStatement() == null then {
       // If the `statement` of the iterationStatement isn't a compoundStatment,
       // wrap it with { }.
       wrapStatementWithBraces(stmt);
     }
   }
 
-  override def enterFunctionDefinition(ctx: CParser.FunctionDefinitionContext): Unit = {
+  override def enterFunctionDefinition(
+      ctx: CParser.FunctionDefinitionContext
+  ): Unit = {
     val compoundStmt = ctx.compoundStatement();
 
     // Insert after {: print "ENTER FUNCTION"
@@ -499,13 +507,13 @@ class Instrumentor(
     def tokenAt(i: Int) = tokens.get(i);
 
     // Skip all the whitespace.
-    while (tokenAt(idx).getChannel() == CLexer.WHITESPACE) {
+    while tokenAt(idx).getChannel() == CLexer.WHITESPACE do {
       idx += 1;
     }
 
     // Next token will either be a comment we might want,
     // or C statement we can ignore.
-    if (tokenAt(idx).getChannel() == CLexer.COMMENT) {
+    if tokenAt(idx).getChannel() == CLexer.COMMENT then {
       val tok = tokenAt(idx);
       val tokText = tok.getText().trim();
 
@@ -531,7 +539,9 @@ class Instrumentor(
     s"__ws_blockIterationFor_$blockName";
   }
 
-  override def enterCompoundStatement(ctx: CParser.CompoundStatementContext): Unit = {
+  override def enterCompoundStatement(
+      ctx: CParser.CompoundStatementContext
+  ): Unit = {
     val startTok = ctx.getStart();
     val iterationVarName = blockIterationIdentifierFor(ctx);
 
@@ -577,7 +587,7 @@ object Instrumentor {
       args: Array[(String, Any)]
   ): String = {
     val template = Instrumentor.constructionSTG.getInstanceOf(templateName);
-    for ((k, v) <- args) {
+    for (k, v) <- args do {
       template.add(k, v);
     }
     return template.render();
@@ -599,7 +609,7 @@ object Instrumentor {
 
     // Add Types from headers
     val headers = StringConstruction.getIncludeHeadersOf(inputProgram);
-    for (hdr <- headers) {
+    for hdr <- headers do {
       HeaderUtils.addTypedefsOfHeaderToScope(hdr, defineScopesPhase.globals);
       HeaderUtils.addSymbolsOfHeaderToScope(hdr, defineScopesPhase.globals);
     }

--- a/src/main/scala/edu/nus/worksheet/instrumentor/StdinMarkup.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/StdinMarkup.scala
@@ -1,7 +1,7 @@
 package edu.nus.worksheet.instrumentor
 
-import org.antlr.v4.runtime._;
-import org.antlr.v4.runtime.tree._;
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.tree.*;
 
 private[instrumentor] class StdinExtractor extends InlineStdinBaseListener {
   var stdinLines = Seq[String]();

--- a/src/main/scala/edu/nus/worksheet/instrumentor/StringConstruction.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/StringConstruction.scala
@@ -1,14 +1,14 @@
 package edu.nus.worksheet.instrumentor
 
-import org.antlr.v4.runtime._
-import org.antlr.v4.runtime.tree._
+import org.antlr.v4.runtime.*
+import org.antlr.v4.runtime.tree.*
 import scala.collection.immutable.List
 import scala.collection.mutable.Stack;
 import scala.collection.mutable.Map;
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import edu.nus.worksheet.instrumentor.Util.currentScopeForContext;
 import edu.nus.worksheet.instrumentor.Util.getANTLRLexerTokensParserFor;
-import HeaderUtils._;
+import HeaderUtils.*;
 
 class StringConstruction(scopes: ParseTreeProperty[Scope])
     extends CBaseListener {
@@ -18,7 +18,7 @@ class StringConstruction(scopes: ParseTreeProperty[Scope])
   private[StringConstruction] var globalScope: GlobalScope = null;
 
   private[StringConstruction] def allCTypes: Seq[CType] =
-    if (globalScope != null) {
+    if globalScope != null then {
       globalScope.symbols.values.toSeq;
     } else {
       Seq();
@@ -26,7 +26,9 @@ class StringConstruction(scopes: ParseTreeProperty[Scope])
 
   // Grammar entry points are either typeInferenceFixture or compilationUnit,
   // set global scope either way.
-  override def enterCompilationUnit(ctx: CParser.CompilationUnitContext): Unit = {
+  override def enterCompilationUnit(
+      ctx: CParser.CompilationUnitContext
+  ): Unit = {
     currentScopeForContext(ctx, scopes) match {
       case gs: GlobalScope => globalScope = gs;
       case _               => ();
@@ -44,11 +46,11 @@ class StringConstruction(scopes: ParseTreeProperty[Scope])
 
   override def exitEnumSpecifier(ctx: CParser.EnumSpecifierContext): Unit = {
     // Keep track of declared enums.
-    if (ctx.enumeratorList() != null) {
+    if ctx.enumeratorList() != null then {
       val enumTag =
-        if (ctx.Identifier() != null) ctx.Identifier().getText() else null;
+        if ctx.Identifier() != null then ctx.Identifier().getText() else null;
 
-      if (enumTag != null) {
+      if enumTag != null then {
         val enum_ = ctypeFromDecl.ctypeOfEnumSpecifier(ctx);
         assert(enum_.enumTag != null);
         currentScopeForContext(ctx, scopes).defineEnum(enum_);
@@ -59,11 +61,11 @@ class StringConstruction(scopes: ParseTreeProperty[Scope])
   override def enterStructOrUnionSpecifier(
       ctx: CParser.StructOrUnionSpecifierContext
   ): Unit = {
-    if (ctx.structDeclarationList() != null) {
+    if ctx.structDeclarationList() != null then {
       val structTag =
-        if (ctx.Identifier() != null) ctx.Identifier().getText() else null;
+        if ctx.Identifier() != null then ctx.Identifier().getText() else null;
 
-      if (structTag != null) {
+      if structTag != null then {
         // Because a forward-declaration doesn't return the type of a
         // declared struct, we need to use a match here.
         ctypeFromDecl.ctypeOfStructOrUnionSpecifier(ctx) match {
@@ -109,11 +111,12 @@ class StringConstruction(scopes: ParseTreeProperty[Scope])
     val declnCType = ctypeFromDecl.ctypeOf(specrs, ctx);
 
     val currentScope = currentScopeForContext(ctx, scopes);
-    if (declnCType.id != null)
-      currentScope.defineSymbol(declnCType);
+    if declnCType.id != null then currentScope.defineSymbol(declnCType);
   }
 
-  override def exitFunctionDefinition(ctx: CParser.FunctionDefinitionContext): Unit = {
+  override def exitFunctionDefinition(
+      ctx: CParser.FunctionDefinitionContext
+  ): Unit = {
     val specifiedType = ctypeFromDecl.ctypeOf(ctx.declarationSpecifiers());
     val definedFun =
       ctypeFromDecl.ctypeOfDeclarator(specifiedType, ctx.declarator())
@@ -207,7 +210,7 @@ object StringConstruction {
         Some(newStructId),
         st.structOrUnion,
         st.structTag,
-        st.members.map(prefix _)
+        st.members.map(prefix)
       )
     }
 
@@ -343,7 +346,7 @@ object StringConstruction {
 
     return ppDirectiveTokens
       .map(_.getText().trim())
-      .map(headerFromIncludeDirective _)
+      .map(headerFromIncludeDirective)
       .flatten
       .toSeq;
   }
@@ -351,7 +354,7 @@ object StringConstruction {
   def main(args: Array[String]): Unit = {
     val cts = getCTypesOfHeader("stdio.h");
 
-    for (ct <- cts) {
+    for ct <- cts do {
       println(ct.id);
     }
   }

--- a/src/main/scala/edu/nus/worksheet/instrumentor/SymbolTable.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/SymbolTable.scala
@@ -89,11 +89,11 @@ trait Scope {
       case PointerType(id, of) =>
         PointerType(id, flattenCType(of));
       case StructType(id, sOrU, tag, members) => {
-        val flatMem = members.map(flattenCType _);
+        val flatMem = members.map(flattenCType);
         StructType(id, sOrU, tag, flatMem);
       }
       case FunctionType(id, rt, params) =>
-        FunctionType(id, flattenCType(rt), params.map(flattenCType _));
+        FunctionType(id, flattenCType(rt), params.map(flattenCType));
       case x => x;
     }
 
@@ -101,13 +101,13 @@ trait Scope {
   // We deal with this using a ForwardDeclaration type.
   // This needs to be flattened.
   def flattenForwardDeclarations(): Unit = {
-    for ((k, v) <- symbols) {
+    for (k, v) <- symbols do {
       symbols += k -> flattenCType(v);
     }
-    for ((k, v) <- declaredTypedefs) {
+    for (k, v) <- declaredTypedefs do {
       declaredTypedefs += k -> flattenCType(v);
     }
-    for ((k, v) <- declaredStructs) {
+    for (k, v) <- declaredStructs do {
       declaredStructs += k -> flattenCType(v).asInstanceOf[StructType];
     }
   }

--- a/src/main/scala/edu/nus/worksheet/instrumentor/Util.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/Util.scala
@@ -1,6 +1,6 @@
 package edu.nus.worksheet.instrumentor
 
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import org.antlr.v4.runtime.RuleContext
 import org.antlr.v4.runtime.tree.ParseTreeProperty
 import org.antlr.v4.runtime.CommonTokenStream
@@ -16,7 +16,7 @@ private[instrumentor] object Util {
   ): (CLexer, CommonTokenStream, CParser) = {
     val headers = StringConstruction.getIncludeHeadersOf(inputProgram);
     val allTypedefNamesInHeaders =
-      headers.map(HeaderUtils.getTypedefNamesOfHeader _).flatten;
+      headers.map(HeaderUtils.getTypedefNamesOfHeader).flatten;
 
     val input = new ANTLRInputStream(inputProgram);
     val lexer = new CLexer(input);
@@ -25,7 +25,7 @@ private[instrumentor] object Util {
 
     parser.addErrorListener(new BaseErrorListener {
       override def syntaxError(
-          recogniser: Recognizer[_, _],
+          recogniser: Recognizer[?, ?],
           offendingSymbol: Any,
           line: Int,
           charPosInLine: Int,
@@ -60,9 +60,9 @@ private[instrumentor] object Util {
   ): Scope = {
     val scope = scopes.get(ctx);
     val parent = ctx.getParent();
-    if (scope != null) {
+    if scope != null then {
       return scope;
-    } else if (parent != null) {
+    } else if parent != null then {
       return currentScopeForContext[T](parent, scopes);
     } else {
       throw new IllegalStateException(
@@ -81,7 +81,7 @@ private[instrumentor] object Util {
   }
 
   def someOrNone(s: String): Option[String] =
-    if (s != null) Some(s) else None;
+    if s != null then Some(s) else None;
 
   // For finding a common real type between two arithmetic types.
   // e.g. commonRealType("int", "float") = "float"

--- a/src/main/scala/edu/nus/worksheet/instrumentor/WorksheetifyException.scala
+++ b/src/main/scala/edu/nus/worksheet/instrumentor/WorksheetifyException.scala
@@ -15,10 +15,8 @@ case class ParseException(
   def dumpString(): String = {
     originalProgram.linesIterator.zipWithIndex
       .map({ case (l, i) =>
-        if (i + 1 == line)
-          l + "  // " + msg;
-        else
-          l;
+        if i + 1 == line then l + "  // " + msg;
+        else l;
       })
       .mkString("\n");
   }

--- a/src/test/scala/edu/nus/worksheet/instrumentor/test/CDeclSpec.scala
+++ b/src/test/scala/edu/nus/worksheet/instrumentor/test/CDeclSpec.scala
@@ -1,12 +1,15 @@
 package edu.nus.worksheet.instrumentor.test
 
-import org.scalatest._
-import flatspec._
-import edu.nus.worksheet.instrumentor._
+import org.scalatest.*
+import flatspec.*
+import edu.nus.worksheet.instrumentor.*
 
 class CDeclSpec extends AnyFlatSpec {
 
-  def assertGibberishToEnglish(gibberish: String, expectedEnglish: String): Unit = {
+  def assertGibberishToEnglish(
+      gibberish: String,
+      expectedEnglish: String
+  ): Unit = {
     val actualEnglish = CDecl.gibberishToEnglish(gibberish);
     assertResult(expectedEnglish)(actualEnglish);
   }

--- a/src/test/scala/edu/nus/worksheet/instrumentor/test/CProgramSpec.scala
+++ b/src/test/scala/edu/nus/worksheet/instrumentor/test/CProgramSpec.scala
@@ -1,8 +1,8 @@
 package edu.nus.worksheet.instrumentor.test
 
-import org.scalatest._
-import flatspec._
-import edu.nus.worksheet.instrumentor._
+import org.scalatest.*
+import flatspec.*
+import edu.nus.worksheet.instrumentor.*
 
 class CProgramSpec extends AnyFlatSpec {
 

--- a/src/test/scala/edu/nus/worksheet/instrumentor/test/CTypeJSONCodecSpec.scala
+++ b/src/test/scala/edu/nus/worksheet/instrumentor/test/CTypeJSONCodecSpec.scala
@@ -1,10 +1,10 @@
 package edu.nus.worksheet.instrumentor.test
 
-import org.scalatest._
-import flatspec._
-import edu.nus.worksheet.instrumentor._
+import org.scalatest.*
+import flatspec.*
+import edu.nus.worksheet.instrumentor.*
 import CTypeCodec.{CTypeEncodeJson, CTypeDecodeJson};
-import argonaut._, Argonaut._;
+import argonaut.*, Argonaut.*;
 
 class CTypeJSONCodecSpec extends AnyFlatSpec {
   def assertIdempotentEncodeAndDecode(ct: CType): Unit = {

--- a/src/test/scala/edu/nus/worksheet/instrumentor/test/CTypeToDeclarationSpec.scala
+++ b/src/test/scala/edu/nus/worksheet/instrumentor/test/CTypeToDeclarationSpec.scala
@@ -1,8 +1,8 @@
 package edu.nus.worksheet.instrumentor.test
 
-import org.scalatest._
-import flatspec._
-import edu.nus.worksheet.instrumentor._
+import org.scalatest.*
+import flatspec.*
+import edu.nus.worksheet.instrumentor.*
 import edu.nus.worksheet.instrumentor.CTypeToDeclaration.declarationOf;
 import edu.nus.worksheet.instrumentor.CTypeToDeclaration.stringOfTypeName;
 

--- a/src/test/scala/edu/nus/worksheet/instrumentor/test/InstrumentorSpec.scala
+++ b/src/test/scala/edu/nus/worksheet/instrumentor/test/InstrumentorSpec.scala
@@ -1,19 +1,21 @@
 package edu.nus.worksheet.instrumentor.test
 
-import org.scalatest._
-import flatspec._
-import edu.nus.worksheet._
-import edu.nus.worksheet.instrumentor._
+import org.scalatest.*
+import flatspec.*
+import edu.nus.worksheet.*
+import edu.nus.worksheet.instrumentor.*
 
 class InstrumentorSpec extends AnyFlatSpec {
-  def assertProgramInstrumentsWithoutErrorsOrWarnings(inputProgram: String): Unit = {
+  def assertProgramInstrumentsWithoutErrorsOrWarnings(
+      inputProgram: String
+  ): Unit = {
     val instrumentedProgram = Instrumentor.instrument(inputProgram);
 
     val prog = new CProgram(instrumentedProgram);
 
     val (warnings, errors) = prog.compile();
 
-    if (!errors.isEmpty) {
+    if !errors.isEmpty then {
       println("Program instrumented to (with errors):");
       println(instrumentedProgram);
     }

--- a/src/test/scala/edu/nus/worksheet/instrumentor/test/StdinMarkupSpec.scala
+++ b/src/test/scala/edu/nus/worksheet/instrumentor/test/StdinMarkupSpec.scala
@@ -1,9 +1,9 @@
 package edu.nus.worksheet.instrumentor.test
 
-import org.scalatest._
-import flatspec._
-import edu.nus.worksheet._
-import edu.nus.worksheet.instrumentor._
+import org.scalatest.*
+import flatspec.*
+import edu.nus.worksheet.*
+import edu.nus.worksheet.instrumentor.*
 
 class StdinMarkupSpec extends AnyFlatSpec {
   "Stdin Markup" should "read basic //IN: comments" in {

--- a/src/test/scala/edu/nus/worksheet/instrumentor/test/StringConstructionSpec.scala
+++ b/src/test/scala/edu/nus/worksheet/instrumentor/test/StringConstructionSpec.scala
@@ -1,10 +1,10 @@
 package edu.nus.worksheet.instrumentor.test
 
-import org.antlr.v4.runtime._
-import org.antlr.v4.runtime.tree._
-import org.scalatest._
-import flatspec._
-import edu.nus.worksheet.instrumentor._
+import org.antlr.v4.runtime.*
+import org.antlr.v4.runtime.tree.*
+import org.scalatest.*
+import flatspec.*
+import edu.nus.worksheet.instrumentor.*
 import edu.nus.worksheet.instrumentor.Util.getANTLRLexerTokensParserFor;
 
 class StringConstructionSpec extends AnyFlatSpec {

--- a/src/test/scala/edu/nus/worksheet/instrumentor/test/TypeInferenceSpec.scala
+++ b/src/test/scala/edu/nus/worksheet/instrumentor/test/TypeInferenceSpec.scala
@@ -1,9 +1,9 @@
 package edu.nus.worksheet.instrumentor.test
 
-import org.scalatest._
-import flatspec._
-import edu.nus.worksheet._
-import edu.nus.worksheet.instrumentor._
+import org.scalatest.*
+import flatspec.*
+import edu.nus.worksheet.*
+import edu.nus.worksheet.instrumentor.*
 import edu.nus.worksheet.instrumentor.TypeInference.inferType;
 
 class TypeInferenceSpec extends AnyFlatSpec {

--- a/src/test/scala/edu/nus/worksheet/instrumentor/test/WorksheetifySpec.scala
+++ b/src/test/scala/edu/nus/worksheet/instrumentor/test/WorksheetifySpec.scala
@@ -2,10 +2,10 @@ package edu.nus.worksheet.instrumentor.test
 
 import java.util.Timer
 import java.util.TimerTask
-import org.scalatest._
-import flatspec._
-import edu.nus.worksheet._
-import edu.nus.worksheet.instrumentor._
+import org.scalatest.*
+import flatspec.*
+import edu.nus.worksheet.*
+import edu.nus.worksheet.instrumentor.*
 import edu.nus.worksheet.tags.{UsesClang, UsesGCC};
 
 trait WorksheetifyBehaviors { this: AnyFlatSpec =>
@@ -47,7 +47,7 @@ int main(int argc, char **argv) { // Line 09
       wsOutput.outputPerLine.get(4) match {
         case Some(s) =>
           assertResult(1, "Should only be declared once")(s.length);
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
     }
 
@@ -93,7 +93,7 @@ int main(int argc, char **argv) { // Line 03
       wsOutput.outputPerLine.get(4) match {
         case Some(xs) =>
           assert(xs.length == 1 && !xs.head.contains("WORKSHEET"));
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
     }
 
@@ -113,11 +113,11 @@ int main(int argc, char **argv) { // Line 02
 
       wsOutput.outputPerLine.get(4) match {
         case Some(scala.collection.Seq(x: String)) => assert(x.contains("a"));
-        case _            => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
       wsOutput.outputPerLine.get(7) match {
         case Some(scala.collection.Seq(x: String)) => assert(x.contains("65"));
-        case _            => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
     }
 
@@ -139,11 +139,12 @@ int main(int argc, char **argv) { // Line 02
 
       wsOutput.outputPerLine.get(8) match {
         case Some(scala.collection.Seq(x: String)) => assert(x.contains("5"));
-        case _            => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
       wsOutput.outputPerLine.get(10) match {
-        case Some(scala.collection.Seq(x: String)) => assert(x.contains("hello"));
-        case _            => fail("No output was given.");
+        case Some(scala.collection.Seq(x: String)) =>
+          assert(x.contains("hello"));
+        case _ => fail("No output was given.");
       }
     }
 
@@ -165,11 +166,12 @@ int main(int argc, char **argv) { // Line 02
 
       wsOutput.outputPerLine.get(8) match {
         case Some(scala.collection.Seq(x: String)) => assert(x.contains("5"));
-        case _            => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
       wsOutput.outputPerLine.get(10) match {
-        case Some(scala.collection.Seq(x: String)) => assert(x.contains("hello"));
-        case _            => fail("No output was given.");
+        case Some(scala.collection.Seq(x: String)) =>
+          assert(x.contains("hello"));
+        case _ => fail("No output was given.");
       }
     }
 
@@ -186,12 +188,14 @@ int main(int argc, char **argv) { // Line 03
       wsOutput.generateWorksheetOutput(); // block until WS done.
 
       wsOutput.outputPerLine.get(5) match {
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.indexOf("5") >= 0, actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.indexOf("5") >= 0, actual);
+        case _ => fail("No output was given.");
       }
       wsOutput.outputPerLine.get(6) match {
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.indexOf("6") >= 0, actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.indexOf("6") >= 0, actual);
+        case _ => fail("No output was given.");
       }
     }
 
@@ -215,8 +219,9 @@ int main(int argc, char **argv) { // Line 03
 
       // Line 6 contains sum. Should be '10'.
       wsOutput.outputPerLine.get(6) match {
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.contains("10"), actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.contains("10"), actual);
+        case _ => fail("No output was given.");
       }
     }
 
@@ -232,12 +237,14 @@ int main(int argc, char **argv) { // Line 02
       wsOutput.generateWorksheetOutput(); // block until WS done.
 
       wsOutput.outputPerLine.get(4) match {
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.contains("3"), actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.contains("3"), actual);
+        case _ => fail("No output was given.");
       }
       wsOutput.outputPerLine.get(5) match {
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.contains("3"), actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.contains("3"), actual);
+        case _ => fail("No output was given.");
       }
     }
 
@@ -292,7 +299,7 @@ int main(int argc, char **argv) { // Line 03
       wsOutput.outputPerLine.get(6) match {
         case Some(scala.collection.Seq(actual: String)) =>
           assert(actual.charAt(actual.length() - 1) == '5', actual);
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
     }
 
@@ -312,7 +319,7 @@ int main(int argc, char **argv) { // Line 03
         // If we couldn't dereference pointers, we'd get a segfault.
         case Some(scala.collection.Seq(actual: String)) =>
           assert(actual.toLowerCase().indexOf("seg") < 0, actual);
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
     }
 
@@ -327,8 +334,9 @@ int main(int argc, char **argv) { // Line 02
       wsOutput.generateWorksheetOutput(); // block until WS done.
 
       wsOutput.outputPerLine.get(4) match {
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.contains("1, 2, 3"), actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.contains("1, 2, 3"), actual);
+        case _ => fail("No output was given.");
       }
     }
 
@@ -345,8 +353,9 @@ int main(int argc, char **argv) { // Line 02
       wsOutput.generateWorksheetOutput(); // block until WS done.
 
       wsOutput.outputPerLine.get(5) match {
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.contains("1, 2, 3"), actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.contains("1, 2, 3"), actual);
+        case _ => fail("No output was given.");
       }
     }
 
@@ -375,25 +384,25 @@ int main(int argc, char **argv) { // line 03
       wsOutput.outputPerLine.get(5) match {
         case Some(scala.collection.Seq(actual: String)) =>
           assertResult(2, actual)(actual.count(_ == ','));
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
 
       wsOutput.outputPerLine.get(8) match {
         case Some(scala.collection.Seq(actual: String)) =>
           assertResult(2, actual)(actual.count(_ == ','));
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
 
       wsOutput.outputPerLine.get(11) match {
         case Some(scala.collection.Seq(actual: String)) =>
           assertResult(3, actual)(actual.count(_ == ','));
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
 
       wsOutput.outputPerLine.get(14) match {
         case Some(scala.collection.Seq(actual: String)) =>
           assertResult(4, actual)(actual.count(_ == ','));
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
     }
 
@@ -415,7 +424,7 @@ int main(int argc, char **argv) { // Line 03
           assert(actual.indexOf("unInt") >= 0, actual);
           assert(actual.indexOf("unFloat") >= 0, actual);
         }
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
     }
 
@@ -437,7 +446,7 @@ int main(int argc, char **argv) { // Line 03
           assert(actual.indexOf("i") >= 0, actual);
           assert(actual.indexOf("f") >= 0, actual);
         }
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
     }
 
@@ -458,7 +467,7 @@ int main(int argc, char **argv) { // Line 03
           assert(actual.indexOf("i") >= 0, actual);
           assert(actual.indexOf("f") >= 0, actual);
         }
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
     }
 
@@ -475,8 +484,9 @@ int main(int argc, char **argv) { // Line 03
       wsOutput.generateWorksheetOutput(); // block until WS done.
 
       wsOutput.outputPerLine.get(6) match {
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.indexOf("FOO") >= 0, actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.indexOf("FOO") >= 0, actual);
+        case _ => fail("No output was given.");
       }
     }
 
@@ -495,8 +505,9 @@ int main(int argc, char **argv) { // Line 05
       wsOutput.generateWorksheetOutput(); // block until WS done.
 
       wsOutput.outputPerLine.get(8) match {
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.indexOf("5") >= 0, actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.indexOf("5") >= 0, actual);
+        case _ => fail("No output was given.");
       }
     }
 
@@ -539,8 +550,9 @@ int main(int argc, char **argv) { // Line 7
         // Actually, it outputs the pointer de-ref, not the name
         // of the function which the function pointer points-to.
         // It would be a nice enhancement to print out e.g. "f1" instead.
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.indexOf("fp") >= 0, actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.indexOf("fp") >= 0, actual);
+        case _ => fail("No output was given.");
       }
     }
 
@@ -555,8 +567,9 @@ int main(int argc, char **argv) { // Line 3
       wsOutput.generateWorksheetOutput(); // block until WS done.
 
       wsOutput.outputPerLine.get(4) match {
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.contains("5"), actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.contains("5"), actual);
+        case _ => fail("No output was given.");
       }
     }
 
@@ -572,8 +585,9 @@ int main(int argc, char **argv) { // Line 3
       wsOutput.generateWorksheetOutput(); // block until WS done.
 
       wsOutput.outputPerLine.get(5) match {
-        case Some(scala.collection.Seq(actual: String)) => assert(actual.contains("5"), actual);
-        case _                 => fail("No output was given.");
+        case Some(scala.collection.Seq(actual: String)) =>
+          assert(actual.contains("5"), actual);
+        case _ => fail("No output was given.");
       }
     }
 
@@ -622,12 +636,12 @@ int main(int argc, char **argv) { // Line 8
 
       wsOutput.outputPerLine.get(9) match {
         case Some(scala.collection.Seq(x)) => assert(x == "0");
-        case _            => fail("No output was given.");
+        case _                             => fail("No output was given.");
       }
 
       wsOutput.outputPerLine.get(10) match {
         case Some(scala.collection.Seq(x)) => assert(x == "1");
-        case _            => fail("No output was given.");
+        case _                             => fail("No output was given.");
       }
     }
 
@@ -647,8 +661,9 @@ int main(int argc, char **argv) { // Line 02
       wsOutput.generateWorksheetOutput(); // block until WS done.
 
       wsOutput.outputPerLine.get(9) match {
-        case Some(scala.collection.Seq(x: String)) => assert(x.contains("1234"));
-        case _            => fail("No output was given.");
+        case Some(scala.collection.Seq(x: String)) =>
+          assert(x.contains("1234"));
+        case _ => fail("No output was given.");
       }
     }
 
@@ -694,7 +709,7 @@ int main(int argc, char **argv) { // Line 03
       wsOutput.outputPerLine.get(5) match {
         case Some(scala.collection.Seq(line: String)) =>
           assert(!line.contains("wsExprResult") && line.contains("funcSquare"));
-        case _    => fail("No output was given.");
+        case _ => fail("No output was given.");
       }
     }
 
@@ -914,7 +929,7 @@ int main(int argc, char **argv) { // Line 03
     wsOutput.outputPerLine.get(5) match {
       case Some(scala.collection.Seq(actual: String)) =>
         assert(actual.toLowerCase().indexOf("seg") >= 0, actual);
-      case _    => fail("No output was given.");
+      case _ => fail("No output was given.");
     }
   }
 }

--- a/src/test/scala/edu/nus/worksheet/instrumentor/test/integration/WorksheetifyIntegrationSpec.scala
+++ b/src/test/scala/edu/nus/worksheet/instrumentor/test/integration/WorksheetifyIntegrationSpec.scala
@@ -4,13 +4,13 @@ import java.nio.file.{Files, Path, Paths}
 import java.nio.charset.StandardCharsets
 
 import scala.io.Source
-import scala.sys.process._
+import scala.sys.process.*
 
-import org.scalatest._
-import flatspec._
+import org.scalatest.*
+import flatspec.*
 
-import edu.nus.worksheet._
-import edu.nus.worksheet.instrumentor._
+import edu.nus.worksheet.*
+import edu.nus.worksheet.instrumentor.*
 
 class WorksheetifyIntegrationSpec extends AnyFlatSpec {
 
@@ -34,15 +34,14 @@ class WorksheetifyIntegrationSpec extends AnyFlatSpec {
     val inputProgramPath = createTempFileWithContents(inputProgram);
 
     val command: Seq[String] =
-      if (System.getProperty("os.name").toLowerCase.contains("windows"))
+      if System.getProperty("os.name").toLowerCase.contains("windows") then
         Seq(
           "cmd",
           "/C",
           s"${installedBinPath.toString}.bat",
           inputProgramPath.toString
         )
-      else
-        Seq(installedBinPath.toString, inputProgramPath.toString)
+      else Seq(installedBinPath.toString, inputProgramPath.toString)
 
     val actualOutput = Process(command).!!
 

--- a/src/test/scala/edu/nus/worksheet/instrumentor/test/integration/WorksheetifyServerIntegrationSpec.scala
+++ b/src/test/scala/edu/nus/worksheet/instrumentor/test/integration/WorksheetifyServerIntegrationSpec.scala
@@ -4,22 +4,22 @@ import java.net.Socket
 import java.net.InetSocketAddress
 import java.net.ConnectException
 import java.net.SocketTimeoutException
-import java.io._
+import java.io.*
 
 import java.nio.file.{Files, Path, Paths}
 import java.nio.charset.StandardCharsets
 
 import scala.io.Source
-import scala.sys.process._
+import scala.sys.process.*
 
-import argonaut.Argonaut._
+import argonaut.Argonaut.*
 import argonaut.Json
 
-import org.scalatest._
-import flatspec._
+import org.scalatest.*
+import flatspec.*
 
-import edu.nus.worksheet._
-import edu.nus.worksheet.instrumentor._
+import edu.nus.worksheet.*
+import edu.nus.worksheet.instrumentor.*
 
 class WorksheetifyServerIntegrationSpec extends AnyFlatSpec {
   val worksheetifyServerPort = 10010;
@@ -31,7 +31,7 @@ class WorksheetifyServerIntegrationSpec extends AnyFlatSpec {
   ): Boolean = {
     println("waiting until port free");
     var retries = 0;
-    while (retries < maxRetries) {
+    while retries < maxRetries do {
       val socket = new Socket();
       try {
         println("attempting connection");
@@ -77,7 +77,7 @@ class WorksheetifyServerIntegrationSpec extends AnyFlatSpec {
       val buffer = new Array[Byte](8)
       var received = ""
       var bytesRead = inputStream.read(buffer)
-      while (bytesRead > 0) {
+      while bytesRead > 0 do {
         received += new String(buffer, 0, bytesRead, "UTF-8")
         bytesRead = inputStream.read(buffer)
       }
@@ -88,7 +88,7 @@ class WorksheetifyServerIntegrationSpec extends AnyFlatSpec {
     } catch {
       case _: Exception => None
     } finally {
-      if (clientSocket != null) {
+      if clientSocket != null then {
         clientSocket.close()
       }
     }
@@ -99,13 +99,12 @@ class WorksheetifyServerIntegrationSpec extends AnyFlatSpec {
       "build/install/c-worksheet-instrumentor/bin/c-worksheetify-server"
     );
     val command: Seq[String] =
-      if (System.getProperty("os.name").toLowerCase.contains("windows"))
+      if System.getProperty("os.name").toLowerCase.contains("windows") then
         Seq(
           s"${installedBinPath.toString}.bat",
           worksheetifyServerPort.toString
         )
-      else
-        Seq(installedBinPath.toString, worksheetifyServerPort.toString)
+      else Seq(installedBinPath.toString, worksheetifyServerPort.toString)
 
     val serverProcess = Process(command).run();
 

--- a/src/test/scala/edu/nus/worksheet/test/WorksheetifyServerRequestSpec.scala
+++ b/src/test/scala/edu/nus/worksheet/test/WorksheetifyServerRequestSpec.scala
@@ -1,0 +1,24 @@
+package edu.nus.worksheet.test
+
+import argonaut.Argonaut.*
+import argonaut.Parse
+import argonaut.Json
+
+import org.scalatest.*
+import flatspec.*
+
+import edu.nus.worksheet.WorksheetifyServer.Request
+import edu.nus.worksheet.WorksheetifyServer.requestCodecJson
+
+class WorksheetifyServerRequestSpec extends AnyFlatSpec {
+
+  "WorksheetifyServer.Request" should "decode JSON" in {
+    val expectedReq = Request("file", "./hello.c", "json-outputlist", None, None);
+
+    val requestJson = """{"inputtype":"file", "input":"./hello.c", "outputtype":"json-outputlist"}""";
+    val actualReq = Parse.decodeOption[Request](requestJson.toString).get;
+
+    assertResult(expectedReq)(actualReq);
+  }
+
+}


### PR DESCRIPTION
Updating the codebase from Scala 2.13 to Scala 3.

This was less tedious to get building compared to the Scala 2.13 <- Scala 2.12 migration.

I used scalafmt to do a treewide rewrite.

Didn't fix most of the warnings. It'll be a quicker & smaller change just to get the code upgraded.